### PR TITLE
释放LoadLibrary()加载的DLL

### DIFF
--- a/dllhijack.cpp
+++ b/dllhijack.cpp
@@ -1,6 +1,6 @@
 #include "dllhijack.h"
 #include <windows.h>
-#include <deque>
+#include <list>
 
 class HmoduleContainer {
  public:
@@ -8,7 +8,7 @@ class HmoduleContainer {
   ~HmoduleContainer() { for (auto handle : Handles) FreeLibrary(handle); }
 
  private:
-  std::deque<HMODULE> Handles;
+  std::list<HMODULE> Handles;
 } g_HmoduleContainer;
 
 typedef struct _UNICODE_STRING {

--- a/dllhijack.cpp
+++ b/dllhijack.cpp
@@ -78,7 +78,7 @@ PEB_LDR_DATA* NtGetPebLdr(void* peb)
 dllname:		被劫持dll的原始名字
 OrigDllPath:	被劫持dll改名后的完整路径
 */
-void SuperDllHijack(LPCWSTR dllname, LPWSTR OrigDllPath)
+void SuperDllHijack(LPCWSTR dllname, LPCWSTR OrigDllPath)
 {
 	WCHAR wszDllName[100] = { 0 };
 	void* peb = NtCurrentPeb();

--- a/dllhijack.cpp
+++ b/dllhijack.cpp
@@ -1,5 +1,15 @@
 #include "dllhijack.h"
 #include <windows.h>
+#include <deque>
+
+class HmoduleContainer {
+ public:
+  void Push(const HMODULE &handle) { Handles.push_back(handle); };
+  ~HmoduleContainer() { for (auto handle : Handles) FreeLibrary(handle); }
+
+ private:
+  std::deque<HMODULE> Handles;
+} g_HmoduleContainer;
 
 typedef struct _UNICODE_STRING {
 	USHORT Length;
@@ -93,8 +103,9 @@ void SuperDllHijack(LPCWSTR dllname, LPCWSTR OrigDllPath)
 		memcpy(wszDllName, data->BaseDllName.Buffer, data->BaseDllName.Length);
 
 		if (!_wcsicmp(wszDllName, dllname)) {
-			HMODULE hMod = LoadLibrary(OrigDllPath);
+			HMODULE hMod = LoadLibraryW(OrigDllPath);
 			data->DllBase = hMod;
+      g_HmoduleContainer.Push(hMod);
 			break;
 		}
 	}

--- a/dllhijack.cpp
+++ b/dllhijack.cpp
@@ -75,8 +75,8 @@ PEB_LDR_DATA* NtGetPebLdr(void* peb)
 }
 
 /*
-dllname:		±»½Ù³ÖdllµÄÔ­Ê¼Ãû×Ö
-OrigDllPath:	±»½Ù³Ödll¸ÄÃûºóµÄÍêÕûÂ·¾¶
+dllname:		è¢«åŠ«æŒdllçš„åŸå§‹åå­—
+OrigDllPath:	è¢«åŠ«æŒdllæ”¹ååçš„å®Œæ•´è·¯å¾„
 */
 void SuperDllHijack(LPCWSTR dllname, LPWSTR OrigDllPath)
 {

--- a/dllhijack.h
+++ b/dllhijack.h
@@ -3,7 +3,7 @@
 #include <windows.h>
 
 /*
-dllname:		±»½Ù³ÖdllµÄÔ­Ê¼Ãû×Ö
-OrigDllPath:	±»½Ù³Ödll¸ÄÃûºóµÄÍêÕûÂ·¾¶
+dllname:		è¢«åŠ«æŒdllçš„åŸå§‹åå­—
+OrigDllPath:	è¢«åŠ«æŒdllæ”¹ååçš„å®Œæ•´è·¯å¾„
 */
 void SuperDllHijack(LPCWSTR dllname, LPWSTR OrigDllPath);

--- a/dllhijack.h
+++ b/dllhijack.h
@@ -6,4 +6,4 @@
 dllname:		被劫持dll的原始名字
 OrigDllPath:	被劫持dll改名后的完整路径
 */
-void SuperDllHijack(LPCWSTR dllname, LPWSTR OrigDllPath);
+void SuperDllHijack(LPCWSTR dllname, LPCWSTR OrigDllPath);


### PR DESCRIPTION
WIN10编译XP上运行时出现了“内存不能为read”崩溃。
`HMODULE hMod = LoadLibrary(OrigDllPath);`
原因是这里的HMODULE没有被释放。